### PR TITLE
Reset lists after removing a child node

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,8 @@ DisplayTreeNode.prototype.remove = function (child) {
   var idx = children.indexOf(child)
   if (idx !== -1) children.splice(idx, 1)
   child.parent = null
+  
+  this.resetLists()
 
   return this
 }


### PR DESCRIPTION
When we add node the the lists are reset. When we remove node they were not. This pull request fixes that.
