### PR TITLE
replace native splice with version that doesn't generate garbage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var splice = require('remove-array-items')
+
 module.exports = DisplayTreeNode
 
 function DisplayTreeNode (data) {
@@ -73,9 +75,9 @@ DisplayTreeNode.prototype.remove = function (child) {
   if (children === null) return this
 
   var idx = children.indexOf(child)
-  if (idx !== -1) children.splice(idx, 1)
+  if (idx !== -1) splice(children, idx, 1)
   child.parent = null
-  
+
   this.resetLists()
 
   return this

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0",
     "unindex-mesh": "^2.0.0"
+  },
+  "dependencies": {
+    "remove-array-items": "^1.0.0"
   }
 }


### PR DESCRIPTION
in a tight simulation loop, when removing lots of items from the display tree, gc churn can be a problem. `remove-array-items` does not generate garbage.